### PR TITLE
Add ZIP lookup and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ npm test
 ```
 
 This compiles the TypeScript sources and executes the tests using Node's built-in test runner.
+
+### Continuous Integration
+
+A GitHub Actions workflow in `.github/workflows/ci.yml` runs the linter and test suite on every push and pull request.
+To enable it:
+
+1. In your repository on GitHub, go to **Settings → Secrets and variables → Actions**.
+2. Add a new repository secret named `OPENROUTER_API_KEY` with your API key.
+
+The workflow maps that secret to an environment variable so integration tests that call OpenRouter can run automatically.

--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+npm test
+```
+
+This compiles the TypeScript sources and executes the tests using Node's built-in test runner.

--- a/app/api/outfit/route.ts
+++ b/app/api/outfit/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { zipToLatLon, getWeather, WeatherSummary } from "@/lib/geoWeather";
 import { callOpenRouterJSON } from "@/lib/openrouter";
+import type { Recommendation } from "@/lib/outfit";
 
 const Input = z.object({
   zip: z.string().min(3),
@@ -56,9 +57,10 @@ ${JSON.stringify(OUTFIT_SCHEMA)}`
   },
 ];
 
-    const recommendation = await callOpenRouterJSON<any>(messages, OUTFIT_SCHEMA);
+    const recommendation = await callOpenRouterJSON<Recommendation>(messages, OUTFIT_SCHEMA);
     return NextResponse.json({ zip, lat, lon, weather, recommendation });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message ?? "Bad request" }, { status: 400 });
+  } catch (e) {
+    const message = e instanceof Error ? e.message : "Bad request";
+    return NextResponse.json({ error: message }, { status: 400 });
   }
 }

--- a/app/apps/outfit/page.tsx
+++ b/app/apps/outfit/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 import { useState } from "react";
+import type { OutfitResponse } from "@/lib/outfit";
 
 export default function OutfitApp() {
   const [zip, setZip] = useState("44118");
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<any>(null);
+  const [result, setResult] = useState<OutfitResponse | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
   async function run() {
@@ -15,7 +16,8 @@ export default function OutfitApp() {
       body: JSON.stringify({ zip })
     });
     if (!r.ok) { setErr(await r.text()); setLoading(false); return; }
-    setResult(await r.json());
+    const data: OutfitResponse = await r.json();
+    setResult(data);
     setLoading(false);
   }
 

--- a/lib/geoWeather.ts
+++ b/lib/geoWeather.ts
@@ -8,6 +8,23 @@ export type WeatherSummary = {
   conditionCode?: number | string;
 };
 
+export async function zipToLatLon(zip: string): Promise<{ lat: number; lon: number }> {
+  const params = new URLSearchParams({
+    postalcode: zip,
+    country: "US",
+    format: "json",
+    limit: "1",
+  });
+  const res = await fetch(
+    `https://nominatim.openstreetmap.org/search?${params.toString()}`
+  );
+  if (!res.ok) throw new Error("ZIP lookup failed");
+  const data = await res.json();
+  const hit = data?.[0];
+  if (!hit?.lat || !hit?.lon) throw new Error("Invalid ZIP");
+  return { lat: parseFloat(hit.lat), lon: parseFloat(hit.lon) };
+}
+
 export async function getWeather(lat: number, lon: number): Promise<WeatherSummary> {
   const w = await fetch(
     `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +

--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -3,16 +3,22 @@ export async function callOpenRouterJSON<T>(
   jsonSchema: unknown,
   model = process.env.OPENROUTER_MODEL || "openrouter/auto"
 ): Promise<T> {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is required");
+
   const res = await fetch("https://openrouter.ai/api/v1/responses", {
     method: "POST",
     headers: {
-      Authorization: `Bearer ${process.env.OPENROUTER_API_KEY!}`,
+      Authorization: `Bearer ${apiKey}`,
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
       model,
       input: messages,
-      response_format: { type: "json_schema", json_schema: jsonSchema },
+      response_format: {
+        type: "json_schema",
+        json_schema: { name: "response", schema: jsonSchema },
+      },
     }),
   });
   if (!res.ok) throw new Error(`OpenRouter failed: ${await res.text()}`);

--- a/lib/outfit.ts
+++ b/lib/outfit.ts
@@ -1,0 +1,15 @@
+import type { WeatherSummary } from "./geoWeather";
+
+export interface Recommendation {
+  outfit: string;
+  packingList: string[];
+  notes: string;
+}
+
+export interface OutfitResponse {
+  zip: string;
+  lat: number;
+  lon: number;
+  weather: WeatherSummary;
+  recommendation: Recommendation;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "tsc lib/*.ts middleware.ts tests/*.ts --outDir dist --module commonjs --esModuleInterop --skipLibCheck && node --test dist/tests/*.test.js"
   },
   "dependencies": {
     "next": "15.5.2",

--- a/tests/geoWeather.test.ts
+++ b/tests/geoWeather.test.ts
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getWeather, zipToLatLon } from '../lib/geoWeather';
+
+function mockFetch(response: Response) {
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = () =>
+    Promise.resolve(response);
+}
+
+test('zipToLatLon returns coordinates', async () => {
+  const body = [{ lat: '40.0', lon: '-80.0' }];
+  mockFetch(new Response(JSON.stringify(body), { status: 200 }));
+  const result = await zipToLatLon('12345');
+  assert.deepEqual(result, { lat: 40, lon: -80 });
+});
+
+test('zipToLatLon throws on invalid data', async () => {
+  mockFetch(new Response(JSON.stringify([]), { status: 200 }));
+  await assert.rejects(() => zipToLatLon('00000'), /Invalid ZIP/);
+});
+
+test('getWeather maps API response to summary', async () => {
+  const body = {
+    current: {
+      temperature_2m: 70,
+      apparent_temperature: 72,
+      windspeed_10m: 5,
+      weathercode: 1,
+    },
+    daily: {
+      precipitation_probability_max: [10],
+      uv_index_max: [3],
+    },
+  };
+  mockFetch(new Response(JSON.stringify(body), { status: 200 }));
+  const summary = await getWeather(0, 0);
+  assert.equal(summary.tempF, 70);
+  assert.equal(summary.feelsLikeF, 72);
+  assert.equal(summary.precipProb, 10);
+  assert.equal(summary.windMph, 5);
+  assert.equal(summary.uvIndexMax, 3);
+  assert.equal(summary.conditionCode, 1);
+});
+
+test('getWeather throws on network error', async () => {
+  mockFetch(new Response('err', { status: 500 }));
+  await assert.rejects(() => getWeather(0, 0), /Weather unavailable/);
+});

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+
+function getMiddleware() {
+  return import('../middleware');
+}
+
+test('rejects requests without auth', async () => {
+  process.env.BASIC_AUTH_USER = 'u';
+  process.env.BASIC_AUTH_PASS = 'p';
+  const { middleware } = await getMiddleware();
+  const req = new NextRequest('https://example.com/secret');
+  const res = middleware(req);
+  assert.equal(res.status, 401);
+});
+
+test('allows valid auth header', async () => {
+  process.env.BASIC_AUTH_USER = 'u';
+  process.env.BASIC_AUTH_PASS = 'p';
+  const { middleware } = await getMiddleware();
+  const auth = Buffer.from('u:p').toString('base64');
+  const req = new NextRequest('https://example.com/secret', {
+    headers: { authorization: `Basic ${auth}` },
+  });
+  const res = middleware(req);
+  assert.equal(res.status, 200);
+});
+
+test('passes through static assets', async () => {
+  process.env.BASIC_AUTH_USER = 'u';
+  process.env.BASIC_AUTH_PASS = 'p';
+  const { middleware } = await getMiddleware();
+  const req = new NextRequest('https://example.com/_next/test.js');
+  const res = middleware(req);
+  assert.equal(res.status, 200);
+});

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -27,3 +27,11 @@ test('throws on non-ok response', async () => {
   mockFetch(new Response('bad', { status: 500 }));
   await assert.rejects(() => callOpenRouterJSON([], {}), /OpenRouter failed/);
 });
+
+test('requires API key', async () => {
+  delete process.env.OPENROUTER_API_KEY;
+  await assert.rejects(
+    () => callOpenRouterJSON([], {}),
+    /OPENROUTER_API_KEY is required/,
+  );
+});

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -1,0 +1,29 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { callOpenRouterJSON } from '../lib/openrouter';
+
+function mockFetch(response: Response) {
+  (globalThis as unknown as { fetch: typeof fetch }).fetch = () =>
+    Promise.resolve(response);
+}
+
+test('parses JSON from OpenRouter output', async () => {
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  const body = { output: [{ content: [{ text: '{"a":1}' }] }] };
+  mockFetch(new Response(JSON.stringify(body), { status: 200 }));
+  const result = await callOpenRouterJSON<{ a: number }>([], {});
+  assert.deepEqual(result, { a: 1 });
+});
+
+test('throws on invalid JSON', async () => {
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  const body = { output: [{ content: [{ text: 'not json' }] }] };
+  mockFetch(new Response(JSON.stringify(body), { status: 200 }));
+  await assert.rejects(() => callOpenRouterJSON([], {}), /Invalid JSON/);
+});
+
+test('throws on non-ok response', async () => {
+  process.env.OPENROUTER_API_KEY = 'test-key';
+  mockFetch(new Response('bad', { status: 500 }));
+  await assert.rejects(() => callOpenRouterJSON([], {}), /OpenRouter failed/);
+});


### PR DESCRIPTION
## Summary
- add `zipToLatLon` helper for converting US ZIP codes to coordinates
- cover OpenRouter client, weather utilities, and auth middleware with unit tests
- document running tests via `npm test`

## Testing
- `npm run lint lib/geoWeather.ts tests/openrouter.test.ts tests/geoWeather.test.ts tests/middleware.test.ts middleware.ts`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae74aafbcc832b8f3050e966444e91