### PR TITLE
test: add openrouter integration test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENROUTER_MODEL: openai/gpt-oss-20b:free
+      BASIC_AUTH_USER: user
+      BASIC_AUTH_PASS: password
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,5 +26,7 @@ jobs:
         run: npm ci
       - name: Lint
         run: npm run lint
+      - name: Build
+        run: npm run build
       - name: Test
         run: npm test

--- a/tests/openrouter.test.ts
+++ b/tests/openrouter.test.ts
@@ -2,6 +2,8 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { callOpenRouterJSON } from '../lib/openrouter';
 
+const ORIGINAL_KEY = process.env.OPENROUTER_API_KEY;
+
 function mockFetch(response: Response) {
   (globalThis as unknown as { fetch: typeof fetch }).fetch = () =>
     Promise.resolve(response);
@@ -34,4 +36,8 @@ test('requires API key', async () => {
     () => callOpenRouterJSON([], {}),
     /OPENROUTER_API_KEY is required/,
   );
+});
+
+test.after(() => {
+  process.env.OPENROUTER_API_KEY = ORIGINAL_KEY;
 });

--- a/tests/outfit.integration.test.ts
+++ b/tests/outfit.integration.test.ts
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+
+async function waitForServer(url: string, timeout = 60000) {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(url);
+      if (res.status > 0) return;
+    } catch {}
+    await delay(1000);
+  }
+  throw new Error('Server did not start');
+}
+
+test(
+  'outfit API returns recommendation',
+  { timeout: 180000 },
+  async () => {
+    process.env.OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || 'openai/gpt-oss-20b:free';
+    process.env.BASIC_AUTH_USER = process.env.BASIC_AUTH_USER || 'user';
+    process.env.BASIC_AUTH_PASS = process.env.BASIC_AUTH_PASS || 'password';
+
+    const server = spawn('npm', ['start'], {
+      env: process.env,
+      stdio: 'inherit',
+    });
+    try {
+      await waitForServer('http://localhost:3000');
+      const auth = Buffer.from(
+        `${process.env.BASIC_AUTH_USER}:${process.env.BASIC_AUTH_PASS}`,
+      ).toString('base64');
+      const res = await fetch('http://localhost:3000/api/outfit', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${auth}`,
+        },
+        body: JSON.stringify({ zip: '10001' }),
+      });
+      const data = await res.json();
+      assert.equal(res.status, 200, data.error || res.status);
+      assert.ok(data.recommendation?.outfit);
+    } finally {
+      server.kill();
+    }
+  },
+);


### PR DESCRIPTION
## Summary
- verify OpenRouter integration by spinning up the app and calling the `/api/outfit` route
- restore OPENROUTER_API_KEY after unit tests to avoid side effects
- pass CI with required env vars and a build step

## Testing
- `npm run build`
- `npm test` *(fails: 400 !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_68af2e5ad7d4832bb0784fa52f0a4d81