### PR TITLE
test: ensure env vars for integration test

### DIFF
--- a/tests/outfit.integration.test.ts
+++ b/tests/outfit.integration.test.ts
@@ -19,9 +19,13 @@ test(
   'outfit API returns recommendation',
   { timeout: 180000 },
   async () => {
-    process.env.OPENROUTER_MODEL = process.env.OPENROUTER_MODEL || 'openai/gpt-oss-20b:free';
-    process.env.BASIC_AUTH_USER = process.env.BASIC_AUTH_USER || 'user';
-    process.env.BASIC_AUTH_PASS = process.env.BASIC_AUTH_PASS || 'password';
+    process.env.OPENROUTER_MODEL = 'openai/gpt-oss-20b:free';
+    process.env.BASIC_AUTH_USER = 'user';
+    process.env.BASIC_AUTH_PASS = 'password';
+
+    if (!process.env.OPENROUTER_API_KEY) {
+      throw new Error('OPENROUTER_API_KEY must be set');
+    }
 
     const server = spawn('npm', ['start'], {
       env: process.env,


### PR DESCRIPTION
## Summary
- pin OPENROUTER_MODEL and Basic Auth creds in the outfit integration test
- fail fast if OPENROUTER_API_KEY is missing

## Testing
- `npm test` *(fails: fetch failed, 400 !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_68af3a933fac832b908321368823b6b4