### PR TITLE
Add User-Agent header to ZIP lookup fetch

### DIFF
--- a/lib/geoWeather.ts
+++ b/lib/geoWeather.ts
@@ -16,7 +16,12 @@ export async function zipToLatLon(zip: string): Promise<{ lat: number; lon: numb
     limit: "1",
   });
   const res = await fetch(
-    `https://nominatim.openstreetmap.org/search?${params.toString()}`
+    `https://nominatim.openstreetmap.org/search?${params.toString()}`,
+    {
+      headers: {
+        "User-Agent": "micro-apps tests (contact@example.com)",
+      },
+    }
   );
   if (!res.ok) throw new Error("ZIP lookup failed");
   const data = await res.json();


### PR DESCRIPTION
## Summary
- include a User-Agent header when calling Nominatim in `zipToLatLon`

## Testing
- `npm run build`
- `OPENROUTER_API_KEY=dummy npm test` *(fails: fetch failed, 400 !== 200)*

------
https://chatgpt.com/codex/tasks/task_e_68af491dc2ec832bbc8f8da985e94755