### PR TITLE
chore: add logging to outfit API

### DIFF
--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -5,6 +5,7 @@ export async function callOpenRouterJSON<T>(
 ): Promise<T> {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) throw new Error("OPENROUTER_API_KEY is required");
+  console.log("[openrouter] request", { model, messages, jsonSchema });
 
   const res = await fetch("https://openrouter.ai/api/v1/responses", {
     method: "POST",
@@ -21,15 +22,20 @@ export async function callOpenRouterJSON<T>(
       },
     }),
   });
-  if (!res.ok) throw new Error(`OpenRouter failed: ${await res.text()}`);
-  const data = await res.json();
+  const raw = await res.text();
+  console.log("[openrouter] status", res.status);
+  console.log("[openrouter] raw response", raw);
+
+  if (!res.ok) throw new Error(`OpenRouter failed: ${raw}`);
+  const data = JSON.parse(raw);
   const text =
     data?.output?.[0]?.content?.[0]?.text ??
     data?.choices?.[0]?.message?.content ??
     "";
   try {
     return JSON.parse(text) as T;
-  } catch {
+  } catch (err) {
+    console.error("[openrouter] invalid JSON", err, text);
     throw new Error(`Invalid JSON from model: ${text}`);
   }
 }


### PR DESCRIPTION
## Summary
- add detailed logging to outfit API route
- log OpenRouter requests and raw responses

## Testing
- `OPENROUTER_API_KEY=dummy npm test` *(fails: fetch failed ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68af500a0c0c832ba81b59627b9c59dd