### PR TITLE
Fix Next.js build to avoid routes manifest error

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint",
     "test": "tsc lib/*.ts middleware.ts tests/*.ts --outDir dist --module commonjs --esModuleInterop --skipLibCheck && node --test dist/tests/*.test.js"


### PR DESCRIPTION
## Summary
- switch production build to `next build` instead of Turbopack to keep routes manifest compatible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af6760f734832bacdc6035a785dc5e