### PR TITLE
Add OpenRouter integration test to CI

### DIFF
--- a/tests/openrouter.integration.test.ts
+++ b/tests/openrouter.integration.test.ts
@@ -1,0 +1,30 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { callOpenRouterJSON } from '../lib/openrouter';
+
+const schema = {
+  type: 'object',
+  properties: { ok: { type: 'boolean' } },
+  required: ['ok'],
+} as const;
+
+test(
+  'calls OpenRouter and parses JSON',
+  { skip: !process.env.OPENROUTER_API_KEY, timeout: 20000 },
+  async () => {
+    const result = await callOpenRouterJSON<{ ok: boolean }>(
+      [
+        {
+          role: 'system',
+          content: 'You are a helpful assistant that only responds in JSON.',
+        },
+        {
+          role: 'user',
+          content: 'Respond with {"ok": true}',
+        },
+      ],
+      schema,
+    );
+    assert.deepEqual(result, { ok: true });
+  },
+);


### PR DESCRIPTION
## Summary
- exercise OpenRouter call in an integration test and verify JSON result
- ensure CI runs the integration test using the `OPENROUTER_API_KEY` secret

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68afa9000b9c832bb258a774949b1cfb