### PR TITLE
Add end-to-end outfit pipeline test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-      OPENROUTER_MODEL: openai/gpt-oss-20b:free
+      OPENROUTER_MODEL: openai/gpt-5-nano
       BASIC_AUTH_USER: user
       BASIC_AUTH_PASS: password
     steps:

--- a/lib/openrouter.ts
+++ b/lib/openrouter.ts
@@ -3,7 +3,7 @@ import { debug } from "./logger";
 export async function callOpenRouterJSON<T>(
   messages: { role: "system" | "user" | "assistant"; content: string }[],
   jsonSchema: unknown,
-  model = process.env.OPENROUTER_MODEL || "openrouter/auto",
+  model = process.env.OPENROUTER_MODEL || "openai/gpt-5-nano",
 ): Promise<T> {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) throw new Error("OPENROUTER_API_KEY is required");

--- a/tests/outfit.integration.test.ts
+++ b/tests/outfit.integration.test.ts
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { NextRequest } from 'next/server';
+import { POST } from '../app/api/outfit/route';
+
+// Full end-to-end test hitting real external services
+// Skip when OPENROUTER_API_KEY is not provided
+
+test(
+  'outfit API returns real recommendation',
+  { skip: !process.env.OPENROUTER_API_KEY, timeout: 30000 },
+  async () => {
+    process.env.VERBOSE = '';
+
+    const req = new NextRequest('http://test/api/outfit', {
+      method: 'POST',
+      body: JSON.stringify({ zip: '10001' }),
+    });
+    const res = await POST(req);
+    const data = await res.json();
+
+    assert.equal(res.status, 200, data.error || String(res.status));
+    assert.equal(data.zip, '10001');
+    assert.ok(data.lat > 40 && data.lat < 41);
+    assert.ok(data.lon > -75 && data.lon < -73);
+    assert.equal(typeof data.weather.tempF, 'number');
+    assert.equal(typeof data.recommendation.outfit, 'string');
+    assert.equal(Array.isArray(data.recommendation.packingList), true);
+    assert.equal(typeof data.recommendation.notes, 'string');
+  }
+);


### PR DESCRIPTION
## Summary
- add full integration test for outfit API hitting real services when OPENROUTER_API_KEY is present
- default OpenRouter calls to openai/gpt-5-nano to avoid rate limits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68afb1d9da2c832b8bf6b951d11a1638